### PR TITLE
Fix new class detection

### DIFF
--- a/pyff/pyff.py
+++ b/pyff/pyff.py
@@ -79,6 +79,11 @@ class ClassesExtractor(NodeVisitor):
         self._methods: int = 0
         self._imported_names: Set[str] = set()
 
+    @property
+    def classnames(self) -> Set[str]:
+        """Return a set of class names in the module"""
+        return {cls.name for cls in self.classes}
+
     def visit_ImportFrom(self, node): # pylint: disable=invalid-name
         """Save imported names"""
         for name in node.names:
@@ -114,7 +119,7 @@ def _pyff_classes(first_ast: Module, second_ast: Module) -> Optional[pf.ClassesP
     first_walker.visit(first_ast)
     second_walker.visit(second_ast)
 
-    appeared = second_walker.classes - first_walker.classes
+    appeared = {cls for cls in second_walker.classes if cls.name not in first_walker.classnames}
 
     return pf.ClassesPyfference(appeared) if appeared else None
 

--- a/tests/examples/02.new
+++ b/tests/examples/02.new
@@ -4,7 +4,6 @@
 #
 # $ example_quotes 02
 # New imported names 'Sequence' from new package 'typing'
-# New class 'Game' with 0 public methods
 # $
 
 """Log of a single VtES game"""

--- a/tests/examples/03.new
+++ b/tests/examples/03.new
@@ -7,7 +7,6 @@
 # New imported names 'Sequence' from new package 'typing'
 # New imported names 'Game' from new package 'vtes.game'
 # New imported names 'GameStore', 'load_store' from new package 'vtes.store'
-# New class 'ParsePlayerAction' derived from imported 'Action' with 0 public methods
 # New function 'add_command'
 # New function 'games_command'
 # Function 'main' changed implementation, newly uses external names 'Path'


### PR DESCRIPTION
Previously, classes present in both versions of the file were reported
as new, which was caused by a buggy difference computation.