### PR TITLE
feat(attributes): Detect differences in class attributes

### DIFF
--- a/pyff/kitchensink.py
+++ b/pyff/kitchensink.py
@@ -1,6 +1,6 @@
 """Placeholders for various elements in output"""
 
-from typing import Iterable, Union, Sized, cast
+from typing import Iterable, Sized
 from colorama import Fore, Style
 
 HL_OPEN = "``"
@@ -24,12 +24,9 @@ def hl(what: str) -> str:  # pylint: disable=invalid-name
     return f"{HL_OPEN}{what}{HL_CLOSE}"
 
 
-def pluralize(name: str, items: Union[Sized, int]) -> str:
+def pluralize(name: str, items: Sized) -> str:
     """Return a pluralized name unless there is exactly one element in container."""
-    try:
-        return f"{name}" if len(cast(Sized, items)) == 1 else f"{name}s"
-    except TypeError:
-        return f"{name}" if cast(int, items) == 1 else f"{name}s"
+    return f"{name}" if len(items) == 1 else f"{name}s"
 
 
 def hlistify(container: Iterable) -> str:

--- a/tests/examples/05.new
+++ b/tests/examples/05.new
@@ -5,13 +5,12 @@
 # $ example_quotes 05
 # New imported 'Sequence' from new 'typing'
 # Class 'Game' changed:
+#   New attributes 'players', 'points', 'winner', 'winning_points'
 #   Method '__init__' changed implementation:
 #     Code semantics changed
 #     Newly uses imported 'Sequence'
 #   New method '__str__'
 # $
-# TODO:
-#   New attributes 'winning_points', 'winner', 'players', 'points'
 
 """Log of a single VtES game"""
 

--- a/tests/examples/06.new
+++ b/tests/examples/06.new
@@ -5,6 +5,8 @@
 # $ example_quotes 06
 # New imported package 're'
 # Class 'Game' changed:
+#   Removed attributes 'players', 'points'
+#   New attribute 'player_results'
 #   Method '__init__' changed implementation:
 #     Code semantics changed
 #   Method '__str__' changed implementation:
@@ -15,8 +17,6 @@
 # $
 # TODO:
 # New module-level variable 'PLAYER_PATTERN'
-#   Removed attributes 'players', 'points'
-#   New attribute 'player_results'
 
 """Log of a single VtES game"""
 


### PR DESCRIPTION
pyff is now able to detect and compare attributes used in methods.
Attribute is considered to be any name that is used as an attribute of
'self' and is assigned into in some method.

To accomodate this, `ClassSummary` was changed to track methods and
attributes as sets of names (previously, only counts were tracked for
methods). This also made possible to simplify the `kitchensink.hl()`
method, because it no longer needs to handle integer arguments.