### PR TITLE
Find differences betweeen directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ ENV/
 # Eclipse
 .project
 .pydevproject
+tags
 
 # pytest
 .pytest_cache

--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -2,6 +2,10 @@
 
 . v/bin/activate
 
+dirtest() {
+  helpers/clitest --prefix '# ' --diff-options '-u --color=always' tests/pyff-dir/all-packages.clitest
+}
+
 example() {
   pyff tests/examples/$1*.old tests/examples/$1*.new
 }
@@ -51,7 +55,8 @@ st() {
     pylint --rcfile=.pylintrc pyff tests/unit/*.py &&
     mypy pyff &&
     helpers/clitest --prefix '# ' --diff-options '-u --color=always' tests/examples/*.new &&
-    helpers/clitest --prefix '# ' --diff-options '-u --color=always' tests/package-examples/*.clitest
+    helpers/clitest --prefix '# ' --diff-options '-u --color=always' tests/package-examples/*.clitest &&
+    helpers/clitest --prefix '# ' --diff-options '-u --color=always' tests/pyff-dir/all-packages.clitest
 }
 
 cov() {

--- a/pyff/directories.py
+++ b/pyff/directories.py
@@ -1,0 +1,99 @@
+"""This module containst code that handles comparing function implementations"""
+
+import logging
+import pathlib
+from typing import Optional, Tuple, FrozenSet, Set
+
+import pyff.packages as pp
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DirectoryPyfference:  # pylint: disable=too-few-public-methods
+    """Represents differences between two directories"""
+
+    def __init__(self, packages: Optional[pp.PackagesPyfference]) -> None:
+        self.packages: Optional[pp.PackagesPyfference] = packages
+
+    def __str__(self):
+        output = []
+        if self.packages:
+            output.append(str(self.packages))
+
+        return "\n".join(output)
+
+    def __bool__(self):
+        return bool(self.packages)
+
+
+def find_those_pythonz(
+    directory: pathlib.Path
+) -> Tuple[FrozenSet[pathlib.Path], FrozenSet[pathlib.Path]]:
+    """Find Python packages and modules in a given directory"""
+    traverse_directories: Set[pathlib.Path] = {directory}
+    packages: Set[pathlib.Path] = set()
+    modules: Set[pathlib.Path] = set()
+    while traverse_directories:
+        candidate = traverse_directories.pop()
+        LOGGER.debug("Checking directory for Python content: %s", candidate)
+        possible_init = candidate / "__init__.py"
+        if possible_init.exists():
+            LOGGER.debug("Directory %s is a Python package", candidate)
+            packages.add(candidate.relative_to(directory))
+            # We do not want to dig into packages
+            continue
+
+        for item in candidate.iterdir():
+            if item.is_file() and item.suffix == ".py":
+                LOGGER.debug("File %s is a Python module", item)
+                modules.add(item.relative_to(directory))
+            elif item.is_dir():
+                LOGGER.debug("Scheduling directory '%s' for traversal", item)
+                traverse_directories.add(item)
+            else:
+                LOGGER.debug("Item %s is not anything Python-related, so we do not care", str(item))
+
+    return (frozenset(packages), frozenset(modules))
+
+
+def pyff_directory(old: pathlib.Path, new: pathlib.Path) -> Optional[DirectoryPyfference]:
+    """Find Python packages and modules in two directories and compare them"""
+    if not (old.is_dir() and new.is_dir()):
+        raise ValueError(f"At least one of {old}, {new} is not an existing directory")
+
+    old_pkgs, old_modules = find_those_pythonz(old)
+    new_pkgs, new_modules = find_those_pythonz(new)
+
+    LOGGER.debug("Packages in the old directory: %s", str(old_pkgs))
+    LOGGER.debug("Packages in the new directory: %s", str(new_pkgs))
+    LOGGER.debug("Modules in the old directory: %s", str(old_modules))
+    LOGGER.debug("Modules in the new directory: %s", str(new_modules))
+
+    removed_packages = old_pkgs - new_pkgs
+    both_packages = old_pkgs.intersection(new_pkgs)
+    new_packages = new_pkgs - old_pkgs
+
+    LOGGER.debug("Removed packages: %s", str(removed_packages))
+    LOGGER.debug("Packages in both directories: %s", str(both_packages))
+    LOGGER.debug("New packages: %s", str(new_packages))
+
+    removed_package_summaries = {pkg: pp.summarize_package(old / pkg) for pkg in removed_packages}
+    changed_packages = {
+        pkg: change
+        for pkg, change in [
+            (pkg, pp.pyff_package(pp.summarize_package(old / pkg), pp.summarize_package(new / pkg)))
+            for pkg in both_packages
+        ]
+        if change is not None
+    }
+    new_package_summaries = {pkg: pp.summarize_package(new / pkg) for pkg in new_packages}
+
+    if removed_package_summaries or changed_packages or new_package_summaries:
+        return DirectoryPyfference(
+            packages=pp.PackagesPyfference(
+                removed_package_summaries, changed_packages, new_package_summaries
+            )
+        )
+
+    return None

--- a/pyff/packages.py
+++ b/pyff/packages.py
@@ -3,12 +3,21 @@ import logging
 import pathlib
 import ast
 
-from typing import Optional, Iterable, FrozenSet, Set
+from typing import Optional, Iterable, FrozenSet, Set, Dict, Mapping
+from types import MappingProxyType
 from astroid.modutils import get_module_files
 
 import pyff.modules as pm
+from pyff.kitchensink import hl, hlistify, pluralize
 
 LOGGER = logging.getLogger(__name__)
+
+
+class PackageSummary:  # pylint: disable=too-few-public-methods
+    """Holds information about a Python package"""
+
+    def __init__(self, package: pathlib.Path) -> None:
+        self.path = package
 
 
 class PackagePyfference:  # pylint: disable=too-few-public-methods
@@ -24,42 +33,97 @@ class PackagePyfference:  # pylint: disable=too-few-public-methods
         return f"PackagePyfference(modules={repr(self.modules)})"
 
 
-def extract_modules(files: Iterable[pathlib.Path], package_path: pathlib.Path) -> FrozenSet[str]:
+class PackagesPyfference:  # pylint: disable=too-few-public-methods
+    """Holds differences between packages in package or directory"""
+
+    def __init__(
+        self,
+        removed: Dict[pathlib.Path, PackageSummary],
+        changed: Dict[pathlib.Path, PackagePyfference],
+        new: Dict[pathlib.Path, PackageSummary],
+    ) -> None:
+        self._removed: Dict[pathlib.Path, PackageSummary] = removed
+        self._changed: Dict[pathlib.Path, PackagePyfference] = changed
+        self._new: Dict[pathlib.Path, PackageSummary] = new
+
+    @property
+    def removed(self) -> Mapping[pathlib.Path, PackageSummary]:
+        """Read-only view on removed packages"""
+        return MappingProxyType(self._removed)
+
+    @property
+    def new(self) -> Mapping[pathlib.Path, PackageSummary]:
+        """Read-only view on new packages"""
+        return MappingProxyType(self._new)
+
+    @property
+    def changed(self) -> Mapping[pathlib.Path, PackagePyfference]:
+        """Read-only view on changed packages"""
+        return MappingProxyType(self._changed)
+
+    def __str__(self):
+        lines = []
+        if self._removed:
+            lines.append(f"Removed {pluralize('package', self._removed)} {hlistify(self._removed)}")
+
+        if self._changed:
+            lines.append(
+                "\n".join(
+                    [
+                        f"Package {hl(package)} changed:\n  " + str(change).replace("\n", "\n  ")
+                        for package, change in self._changed.items()
+                    ]
+                )
+            )
+
+        if self._new:
+            lines.append(f"New {pluralize('package', self._new)} {hlistify(self._new)}")
+
+        return "\n".join(lines)
+
+    def __bool__(self):
+        return bool(self._removed or self._changed or self._new)
+
+
+def extract_modules(files: Iterable[pathlib.Path], package: PackageSummary) -> FrozenSet[str]:
     """Extract direct modules of a packages (i.e. not modules of subpackages"""
-    LOGGER.debug(str(files))
-    LOGGER.debug(str(package_path))
-    return frozenset({module.name for module in files if module.parents[0] == package_path})
+    return frozenset({module.name for module in files if module.parents[0] == package.path})
 
 
 def _compare_module_in_packages(
-    module: pathlib.Path, old_package: pathlib.Path, new_package: pathlib.Path
+    module: pathlib.Path, old_package: PackageSummary, new_package: PackageSummary
 ) -> Optional[pm.ModulePyfference]:
     """Compare one module in two packages"""
-    old_module = old_package / module
-    new_module = new_package / module
+    old_module = old_package.path / module
+    new_module = new_package.path / module
 
     return pm.pyff_module_code(old_module.read_text(), new_module.read_text())
 
 
-def _summarize_module_in_package(module: pathlib.Path, package: pathlib.Path) -> pm.ModuleSummary:
-    full_path = package / module
+def summarize_package(package: pathlib.Path) -> PackageSummary:
+    """Create a PackageSummary for a given path"""
+    return PackageSummary(package)
+
+
+def _summarize_module_in_package(module: pathlib.Path, package: PackageSummary) -> pm.ModuleSummary:
+    full_path = package.path / module
     module_ast = ast.parse(full_path.read_text())
     return pm.ModuleSummary(str(module), module_ast)
 
 
 def pyff_package(
-    old_package: pathlib.Path, new_package: pathlib.Path
+    old_package: PackageSummary, new_package: PackageSummary
 ) -> Optional[PackagePyfference]:
-    """Given *paths* to two versions of a package, return differences between them"""
+    """Given summaries of two versions of a package, return differences between them"""
     old_files: Set[pathlib.Path] = {
-        pathlib.Path(module) for module in get_module_files(old_package, ())
+        pathlib.Path(module) for module in get_module_files(old_package.path, ())
     }
     new_files: Set[pathlib.Path] = {
-        pathlib.Path(module) for module in get_module_files(new_package, ())
+        pathlib.Path(module) for module in get_module_files(new_package.path, ())
     }
 
-    LOGGER.debug("Files of the old package %s: %s", old_package, old_files)
-    LOGGER.debug("Files of the new package %s: %s", new_package, new_files)
+    LOGGER.debug("Files of the old package %s: %s", str(old_package.path), old_files)
+    LOGGER.debug("Files of the new package %s: %s", str(new_package.path), new_files)
 
     old_modules: Set[pathlib.Path] = {
         pathlib.Path(module) for module in extract_modules(old_files, old_package)
@@ -99,3 +163,10 @@ def pyff_package(
         return PackagePyfference(modules)
 
     return None
+
+
+def pyff_package_path(old: pathlib.Path, new: pathlib.Path) -> Optional[PackagePyfference]:
+    """Given *paths* to two versions of a package, return differences between them"""
+    old_summary = summarize_package(old)
+    new_summary = summarize_package(new)
+    return pyff_package(old_summary, new_summary)

--- a/pyff/run.py
+++ b/pyff/run.py
@@ -7,7 +7,8 @@ from argparse import ArgumentParser
 from typing import Callable
 
 from pyff.modules import pyff_module_code
-from pyff.packages import pyff_package
+from pyff.packages import pyff_package_path
+from pyff.directories import pyff_directory
 from pyff.kitchensink import highlight, HIGHLIGHTS
 
 LOGGER = logging.getLogger(__name__)
@@ -32,7 +33,10 @@ def _pyff_that(function: Callable, what: str) -> None:
     changes = function(pathlib.Path(args.old), pathlib.Path(args.new))
 
     if changes is None:
-        print(f"Pyff did not detect any significant difference between {args.old} and {args.new}")
+        print(
+            f"Pyff did not detect any significant difference between "
+            f"{what} '{args.old}' and '{args.new}'"
+        )
         sys.exit(0)
 
     print(highlight(str(changes), args.highlight))
@@ -54,7 +58,12 @@ def pyffmod() -> None:
 
 def pyffpkg() -> None:
     """Entry point for the `pyff-package` command"""
-    _pyff_that(pyff_package, "package")
+    _pyff_that(pyff_package_path, "package")
+
+
+def pyffdir() -> None:
+    """Entry point for the `pyff-dir` command"""
+    _pyff_that(pyff_directory, "directory")
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,11 @@ setuptools.setup(
     setup_requires=["pytest-runner", "pytest-bdd", "pytest-pylint", "pytest-mypy", "pytest-cov"],
     tests_require=["pytest", "pylint", "mypy"],
     install_requires=["colorama"],
-    entry_points={"console_scripts": ["pyff=pyff.run:pyffmod", "pyff-package=pyff.run:pyffpkg"]},
+    entry_points={
+        "console_scripts": [
+            "pyff=pyff.run:pyffmod",
+            "pyff-package=pyff.run:pyffpkg",
+            "pyff-dir=pyff.run:pyffdir",
+        ]
+    },
 )

--- a/tests/pyff-dir/all-packages.clitest
+++ b/tests/pyff-dir/all-packages.clitest
@@ -1,0 +1,14 @@
+# Expected output for `clitest`
+# $ . helpers/helpers.sh
+# $
+#
+# $ pyff-dir tests/package-examples/old tests/package-examples/new --highlight-names quotes
+# Package 'pkg01' changed:
+#   Module '__init__.py' changed:
+#     New imported 'Action', 'ArgumentParser' from new 'argparse'
+#     New class 'ParsePlayerAction' derived from imported 'Action' with 0 public methods
+#     Function 'main' changed implementation:
+#       Code semantics changed
+#       Newly uses imported 'ArgumentParser'
+# $
+

--- a/tests/unit/test_directories.py
+++ b/tests/unit/test_directories.py
@@ -1,0 +1,117 @@
+# pylint: disable=missing-docstring, no-self-use, too-few-public-methods
+
+import pathlib
+from unittest.mock import MagicMock
+import pytest
+import pyff.packages as pp
+import pyff.directories as pd
+
+
+class TestDirectoryPyfference:
+    def test_packages(self):
+        mock_packages = MagicMock(spec=pp.PackagesPyfference)
+        mock_packages.__str__.return_value = "Packages differ"
+        change = pd.DirectoryPyfference(packages=mock_packages)
+        assert change
+        assert change.packages
+        assert str(change) == "Packages differ"
+
+    def test_empty(self):
+        change = pd.DirectoryPyfference(packages=None)
+        assert not change
+        assert str(change) == ""
+
+
+class TestFindThosePythonz:
+    def test_package(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("toplevel/package/__init__.py")
+
+        packages, _ = pd.find_those_pythonz(pathlib.Path("toplevel"))
+        assert packages == {pathlib.Path("package")}
+
+    def test_only_toplevel_package(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("toplevel/package/__init__.py")
+        fs.create_file("toplevel/package/subpackage/__init__.py")
+
+        packages, _ = pd.find_those_pythonz(pathlib.Path("toplevel"))
+        assert packages == {pathlib.Path("package")}
+
+    def test_package_somewhere_deep(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("toplevel/somewhere/really/deep/is/a/package/__init__.py")
+
+        packages, _ = pd.find_those_pythonz(pathlib.Path("toplevel"))
+        assert packages == {pathlib.Path("somewhere/really/deep/is/a/package")}
+
+    def test_ignore_nonpython_stuff(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("toplevel/package/__init__.py")
+        fs.create_file("toplevel/README")
+        fs.create_file("toplevel/deeper/some-legacy-c-stuff.c")
+
+        packages, _ = pd.find_those_pythonz(pathlib.Path("toplevel"))
+        assert packages == {pathlib.Path("package")}
+
+    def test_module(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("toplevel/module.py")
+        _, modules = pd.find_those_pythonz(pathlib.Path("toplevel"))
+        assert modules == {pathlib.Path("module.py")}
+
+    def test_module_deep(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("toplevel/somewhere/deep/is/a/module.py")
+        _, modules = pd.find_those_pythonz(pathlib.Path("toplevel"))
+        assert modules == {pathlib.Path("somewhere/deep/is/a/module.py")}
+
+    def test_everything(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("toplevel/package/__init__.py")
+        fs.create_file("toplevel/somewhere/really/deep/is/a/package/__init__.py")
+        fs.create_file("toplevel/module.py")
+        fs.create_file("toplevel/somewhere/deep/is/a/module.py")
+
+        packages, modules = pd.find_those_pythonz(pathlib.Path("toplevel"))
+        assert packages == {
+            pathlib.Path("somewhere/really/deep/is/a/package"),
+            pathlib.Path("package"),
+        }
+        assert modules == {pathlib.Path("somewhere/deep/is/a/module.py"), pathlib.Path("module.py")}
+
+
+class TestPyffDirectory:
+    def test_identical(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("old/package/__init__.py")
+        fs.create_file("new/package/__init__.py")
+
+        assert pd.pyff_directory(pathlib.Path("old"), pathlib.Path("new")) is None
+
+    def test_invalid(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("old")
+        fs.create_file("dir/pkg/__init__.py")
+
+        with pytest.raises(ValueError):
+            pd.pyff_directory(pathlib.Path("old"), pathlib.Path("dir"))
+
+        with pytest.raises(ValueError):
+            pd.pyff_directory(pathlib.Path("dir"), pathlib.Path("old"))
+
+        with pytest.raises(ValueError):
+            pd.pyff_directory(pathlib.Path("dir"), pathlib.Path("nonexistent"))
+
+    def test_remove_package(self, fs):  # pylint: disable=invalid-name
+        fs.create_file("old/pkg/__init__.py")
+        fs.create_dir("new")
+        change = pd.pyff_directory(pathlib.Path("old"), pathlib.Path("new"))
+        assert change
+        assert pathlib.Path("pkg") in change.packages.removed
+
+    def test_add_package(self, fs):  # pylint: disable=invalid-name
+        fs.create_dir("old")
+        fs.create_file("new/pkg/__init__.py")
+        change = pd.pyff_directory(pathlib.Path("old"), pathlib.Path("new"))
+        assert change
+        assert pathlib.Path("pkg") in change.packages.new
+
+    def test_changed_package(self, fs):  # pylint: disable=invalid-name
+        fs.create_dir("old/pkg/__init__.py")
+        fs.create_file("new/pkg/__init__.py")
+        fs.create_file("new/pkg/module.py")
+        change = pd.pyff_directory(pathlib.Path("old"), pathlib.Path("new"))
+        assert change
+        assert pathlib.Path("pkg") in change.packages.changed

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -6,6 +6,36 @@ import pyff.modules as pm
 import pyff.packages as pp
 
 
+class TestPackagesPyfference:
+    def test_empty(self):
+        assert not pp.PackagesPyfference(None, None, None)
+
+    def test_removed(self):
+        path = pathlib.Path("path/to/package")
+        summary = pp.PackageSummary(path)
+        change = pp.PackagesPyfference(removed={path: summary}, changed=None, new=None)
+        assert change
+        assert path in change.removed
+        assert str(change) == "Removed package ``path/to/package''"
+
+    def test_new(self):
+        path = pathlib.Path("path/to/package")
+        summary = pp.PackageSummary(path)
+        change = pp.PackagesPyfference(new={path: summary}, changed=None, removed=None)
+        assert change
+        assert path in change.new
+        assert str(change) == "New package ``path/to/package''"
+
+    def test_changed(self):
+        path = pathlib.Path("path/to/package")
+        inner_change = MagicMock(spec=pp.PackagePyfference)
+        inner_change.__str__.return_value = "Total rewrite"
+        change = pp.PackagesPyfference(changed={path: inner_change}, removed=None, new=None)
+        assert change
+        assert path in change.changed
+        assert str(change) == "Package ``path/to/package'' changed:\n  Total rewrite"
+
+
 class TestPackagePyfference:
     def test_sanity(self):
         mock_modules = MagicMock(spec=pm.ModulesPyfference)
@@ -18,11 +48,13 @@ class TestPackagePyfference:
 class TestExtractions:
     def test_extract_module(self):
         assert pp.extract_modules(
-            [pathlib.Path("a/b.py"), pathlib.Path("a/b/c.py")], pathlib.Path("a")
+            [pathlib.Path("a/b.py"), pathlib.Path("a/b/c.py")],
+            pp.summarize_package(pathlib.Path("a")),
         ) == {"b.py"}
         assert (
             pp.extract_modules(
-                [pathlib.Path("a/b/b.py"), pathlib.Path("a/b/c.py")], pathlib.Path("a")
+                [pathlib.Path("a/b/b.py"), pathlib.Path("a/b/c.py")],
+                pp.summarize_package(pathlib.Path("a")),
             )
             == frozenset()
         )
@@ -30,7 +62,7 @@ class TestExtractions:
 
 class TestPyffPackage:
     @pytest.fixture
-    def sample_package(self, fs):  # pylint: disable=invalid-name
+    def sample_package_path(self, fs):  # pylint: disable=invalid-name
         fs.create_dir("pkg")
         fs.create_file("pkg/__init__.py")
         fs.create_file("pkg/module.py")
@@ -38,18 +70,33 @@ class TestPyffPackage:
         return pathlib.Path("pkg")
 
     @pytest.fixture
-    def sample_with_new_module(self, fs):  # pylint: disable=invalid-name
+    def sample_with_new_module_path(self, fs):  # pylint: disable=invalid-name
         fs.create_dir("pkg_new")
         fs.create_file("pkg_new/__init__.py")
         fs.create_file("pkg_new/module.py")
         fs.create_file("pkg_new/new.py")
+
         return pathlib.Path("pkg_new")
+
+    @pytest.fixture
+    def sample_package(self, sample_package_path):  # pylint: disable=invalid-name
+        return pp.summarize_package(sample_package_path)
+
+    @pytest.fixture
+    def sample_with_new_module(self, sample_with_new_module_path):  # pylint: disable=invalid-name
+        return pp.summarize_package(sample_with_new_module_path)
 
     def test_identical(self, sample_package):
         assert pp.pyff_package(sample_package, sample_package) is None
 
     def test_new_module(self, sample_package, sample_with_new_module):
         change = pp.pyff_package(sample_package, sample_with_new_module)
+        assert change is not None
+        assert change.modules is not None
+        assert "new.py" in change.modules.new
+
+    def test_pyff_package_path(self, sample_package_path, sample_with_new_module_path):
+        change = pp.pyff_package_path(sample_package_path, sample_with_new_module_path)
         assert change is not None
         assert change.modules is not None
         assert "new.py" in change.modules.new


### PR DESCRIPTION
Given paths to two directories representing different codebase states
(like two different revision of the code repository), find Python
content (packages and modules) in the directory and output the
difference between them: packages & modules appearing, disappearing and
changing.